### PR TITLE
Added extension for SQLAlchemy

### DIFF
--- a/automapper/extensions/sqlalchemy.py
+++ b/automapper/extensions/sqlalchemy.py
@@ -1,0 +1,19 @@
+from sqlalchemy import inspect
+
+from typing import Type, Iterable
+
+from automapper import Mapper
+
+
+def sqlalchemy_spec_decide(obj_type: Type[object]) -> bool:
+    return inspect(obj_type, raiseerr=False) is not None
+
+
+def spec_function(target_cls: Type[object]) -> Iterable[str]:
+    inspector = inspect(target_cls)
+    attrs = [x.key for x in inspector.attrs]
+    return attrs
+
+
+def extend(mapper: Mapper) -> None:
+    mapper.add_spec(sqlalchemy_spec_decide, spec_function)

--- a/tests/test_for_sqlalchemy_extention.py
+++ b/tests/test_for_sqlalchemy_extention.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+from sqlalchemy import Column, Integer, String
+
+
+class UserInfo(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    full_name = Column(String)
+    public_name = Column(String)
+    hobbies = Column(String)
+    def __repr__(self):
+        return "<User(full_name='%s', public_name='%s', hobbies='%s')>" % (
+            self.full_name,
+            self.public_name,
+            self.hobbies,
+        )
+
+class PublicUserInfo(Base):
+    __tablename__ = 'public_users'
+    id = Column(Integer, primary_key=True)
+    public_name = Column(String)
+    hobbies = Column(String)
+
+import pytest
+
+from automapper import mapper as default_mapper
+from automapper import Mapper, MappingError
+
+class SQLalchemyORMExtensionTest(TestCase):
+    """These scenarios are known for ORM systems.
+    e.g. Model classes in Tortoise ORM
+    """
+
+    def setUp(self) -> None:
+        self.mapper = Mapper()
+
+    def test_map__fails_for_sqlalchemy_mapping(self):
+        obj = UserInfo(
+            id=2,
+            full_name="Danny DeVito",
+            public_name="dannyd",
+            hobbies="acting, comedy, swimming",
+        )
+        with pytest.raises(MappingError):
+            self.mapper.to(PublicUserInfo).map(obj)
+
+
+    def test_map__global_mapper_works_with_provided_sqlalchemy_extension(self):
+        obj = UserInfo(
+            id=2,
+            full_name="Danny DeVito",
+            public_name="dannyd",
+            hobbies="acting, comedy, swimming",
+        )
+
+        result = default_mapper.to(PublicUserInfo).map(obj)
+
+        assert result.id == 2
+        assert result.public_name == "dannyd"
+        assert result.hobbies == "acting, comedy, swimming"
+        with pytest.raises(AttributeError):
+            getattr(result, "full_name")


### PR DESCRIPTION
I added an extension for [SQLAlchemy](https://docs.sqlalchemy.org/en/14/orm/). It is very similar to the extension provided for Tortoise.
I use the [inspection capabilities](https://docs.sqlalchemy.org/en/14/core/inspection.html?highlight=inspect#module-sqlalchemy.inspection) of SQLAlchemy to determine if it is applicable. Then the field values are extracted from `attrs` attribute of the `Inspector` object. These are not necessarily equal to the arguments accepted by `__init__`, but should cover most cases.

A minimalistic unittest (essentially a copy of the tortoise unittest) is also provided.