### PR TITLE
Correcting mapper variable name in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ obj = UserInfo(
     hobbies=["acting", "comedy", "swimming"]
 )
 
-result = default_mapper.to(PublicUserInfo).map(obj)
+result = mapper.to(PublicUserInfo).map(obj)
 # same behaviour with preregistered mapping
 
 print(vars(result))
@@ -186,7 +186,7 @@ obj = UserInfo(
     using_db=True
 )
 
-result = default_mapper.to(PublicUserInfo).map(obj)
+result = mapper.to(PublicUserInfo).map(obj)
 # same behaviour with preregistered mapping
 
 # filtering out protected fields that start with underscore "_..."


### PR DESCRIPTION
`automapper.mapper` is imported as `mapper`, not as `default_mapper`. Probably, this code was copied from unittest and not corrected.