### PR TITLE
Improved error message when no spec found.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Coming in future, but not yet
 sphinx-docs/
+
+# PyCharm settings
+.idea/

--- a/README.md
+++ b/README.md
@@ -124,6 +124,46 @@ print(vars(public_user_info))
 # {'full_name': 'John Cusack', 'profession': 'engineer'}
 ```
 
+## Use of Deepcopy
+By default, automapper performs a recursive deepcopy() on all attributes. This makes sure that changes in the attributes of the source
+do not affect the target and vice-versa:
+
+```python
+from dataclasses import dataclass
+from automapper import mapper
+
+@dataclass
+class Address:
+  street: str
+  number: int
+  zip_code: int
+  city: str
+  
+class PersonInfo:
+    def __init__(self, name: str, age: int, address: Address):
+        self.name = name
+        self.age = age
+        self.address = address
+
+class PublicPersonInfo:
+    def __init__(self, name: str, address: Address):
+        self.name = name
+        self.address = address
+        
+address = Address(street="Main Street", number=1, zip_code=100001, city='Test City')
+info = PersonInfo('John Doe', age=35, address=address)
+
+public_info = mapper.to(PublicPersonInfo).map(info)
+assert address is not public_info.address
+```
+
+To disable this behavior, you may pass `deepcopy=False` to either `mapper.map()` or to `mapper.add()`. If both are passed,
+the argument of the `.map()` call has priority. E.g.
+
+```python
+public_info = mapper.to(PublicPersonInfo).map(info, deepcopy=False)
+assert address is public_info.address
+```
 
 ## Extensions
 `py-automapper` has few predefined extensions for mapping support to classes for frameworks:

--- a/automapper/exceptions.py
+++ b/automapper/exceptions.py
@@ -8,6 +8,4 @@ class MappingError(Exception):
 
 class CircularReferenceError(Exception):
     def __init__(self, *args: object) -> None:
-        super().__init__(
-            "Mapper does not support objects with circular references yet", *args
-        )
+        super().__init__("Mapper does not support objects with circular references yet", *args)

--- a/automapper/extensions/default.py
+++ b/automapper/extensions/default.py
@@ -11,9 +11,7 @@ def __init_method_classifier__(target_cls: Type[T]) -> bool:
     return (
         hasattr(target_cls, "__init__")
         and hasattr(getattr(target_cls, "__init__"), "__annotations__")
-        and isinstance(
-            getattr(getattr(target_cls, "__init__"), "__annotations__"), dict
-        )
+        and isinstance(getattr(getattr(target_cls, "__init__"), "__annotations__"), dict)
         and getattr(getattr(target_cls, "__init__"), "__annotations__")
     )
 

--- a/automapper/mapper.py
+++ b/automapper/mapper.py
@@ -105,9 +105,7 @@ class Mapper:
         ...
 
     @overload
-    def add_spec(
-        self, classifier: ClassifierFunction[T], spec_func: SpecFunction[T]
-    ) -> None:
+    def add_spec(self, classifier: ClassifierFunction[T], spec_func: SpecFunction[T]) -> None:
         """Add a spec function for all classes identified by classifier function.
 
         Parameters:
@@ -186,8 +184,7 @@ class Mapper:
             # transform mapping if it's from source class field
             common_fields_mapping = {
                 target_obj_field: getattr(obj, source_field[len(obj_type_preffix) :])
-                if isinstance(source_field, str)
-                and source_field.startswith(obj_type_preffix)
+                if isinstance(source_field, str) and source_field.startswith(obj_type_preffix)
                 else source_field
                 for target_obj_field, source_field in target_cls_field_mappings.items()
             }
@@ -220,9 +217,7 @@ class Mapper:
             if classifier(target_cls):
                 return self._classifier_specs[classifier](target_cls)
 
-        raise MappingError(
-            f"No spec function is added for base class of {type(target_cls)}"
-        )
+        raise MappingError(f"No spec function is added for base class of {type(target_cls)}")
 
     def _map_subobject(
         self, obj: S, _visited_stack: Set[int], skip_none_values: bool = False
@@ -246,9 +241,7 @@ class Mapper:
             if is_sequence(obj):
                 if isinstance(obj, dict):
                     result = {
-                        k: self._map_subobject(
-                            v, _visited_stack, skip_none_values=skip_none_values
-                        )
+                        k: self._map_subobject(v, _visited_stack, skip_none_values=skip_none_values)
                         for k, v in obj.items()
                     }
                 else:

--- a/automapper/mapper.py
+++ b/automapper/mapper.py
@@ -217,7 +217,7 @@ class Mapper:
             if classifier(target_cls):
                 return self._classifier_specs[classifier](target_cls)
 
-        raise MappingError(f"No spec function is added for base class of {type(target_cls)}")
+        raise MappingError(f"No spec function is added for base class of {target_cls.__name__!r}")
 
     def _map_subobject(
         self, obj: S, _visited_stack: Set[int], skip_none_values: bool = False

--- a/tests/test_automapper.py
+++ b/tests/test_automapper.py
@@ -20,9 +20,7 @@ class ChildClass(ParentClass):
 
     @classmethod
     def fields(cls) -> Iterable[str]:
-        return (
-            field for field in cls.__init__.__annotations__.keys() if field != "return"
-        )
+        return (field for field in cls.__init__.__annotations__.keys() if field != "return")
 
 
 class AnotherClass:
@@ -68,16 +66,12 @@ class AutomapperTest(TestCase):
     def test_add_spec__adds_to_internal_collection(self):
         self.mapper.add_spec(ParentClass, custom_spec_func)
         assert ParentClass in self.mapper._class_specs
-        assert ["num", "text", "flag"] == self.mapper._class_specs[ParentClass](
-            ChildClass
-        )
+        assert ["num", "text", "flag"] == self.mapper._class_specs[ParentClass](ChildClass)
 
     def test_add_spec__error_on_adding_same_class_spec(self):
         self.mapper.add_spec(ParentClass, custom_spec_func)
         with pytest.raises(DuplicatedRegistrationError):
-            self.mapper.add_spec(
-                ParentClass, lambda concrete_type: ["field1", "field2"]
-            )
+            self.mapper.add_spec(ParentClass, lambda concrete_type: ["field1", "field2"])
 
     def test_add_spec__adds_to_internal_collection_for_classifier(self):
         self.mapper.add_spec(classifier_func, spec_func)

--- a/tests/test_automapper_dict_field.py
+++ b/tests/test_automapper_dict_field.py
@@ -1,7 +1,7 @@
-from copy import deepcopy
 from typing import Any, Dict
+from unittest import TestCase
 
-from automapper import mapper
+from automapper import mapper, create_mapper
 
 
 class Candy:
@@ -12,36 +12,60 @@ class Candy:
 
 class Shop:
     def __init__(self, products: Dict[str, Any], annual_income: int):
-        self.products: Dict[str, Any] = deepcopy(products)
+        self.products: Dict[str, Any] = products
         self.annual_income = annual_income
 
 
 class ShopPublicInfo:
     def __init__(self, products: Dict[str, Any]):
-        self.products: Dict[str, Any] = deepcopy(products)
+        self.products: Dict[str, Any] = products
 
 
-def test_map__with_dict_field():
-    products = {
-        "magazines": ["Forbes", "Time", "The New Yorker"],
-        "candies": [
-            Candy("Reese's cups", "The Hershey Company"),
-            Candy("Snickers", "Mars, Incorporated"),
-        ],
-    }
-    shop = Shop(products=products, annual_income=10000000)
+class AutomapperTest(TestCase):
+    def setUp(self) -> None:
+        products = {
+            "magazines": ["Forbes", "Time", "The New Yorker"],
+            "candies": [
+                Candy("Reese's cups", "The Hershey Company"),
+                Candy("Snickers", "Mars, Incorporated"),
+            ],
+        }
+        self.shop = Shop(products=products, annual_income=10000000)
+        self.mapper = create_mapper()
 
-    public_info = mapper.to(ShopPublicInfo).map(shop)
+    def test_map__with_dict_field(self):
+        public_info = mapper.to(ShopPublicInfo).map(self.shop)
 
-    assert public_info.products["magazines"] == shop.products["magazines"]
-    assert id(public_info.products["magazines"]) != id(shop.products["magazines"])
+        self.assertEqual(public_info.products["magazines"], self.shop.products["magazines"])
+        self.assertNotEqual(id(public_info.products["magazines"]), id(self.shop.products["magazines"]))
 
-    assert public_info.products["candies"] != shop.products["candies"]
-    assert public_info.products["candies"][0] != shop.products["candies"][0]
-    assert public_info.products["candies"][1] != shop.products["candies"][1]
+        self.assertNotEqual(public_info.products["candies"], self.shop.products["candies"])
+        self.assertNotEqual(public_info.products["candies"][0], self.shop.products["candies"][0])
+        self.assertNotEqual(public_info.products["candies"][1], self.shop.products["candies"][1])
 
-    assert public_info.products["candies"][0].name == "Reese's cups"
-    assert public_info.products["candies"][0].brand == "The Hershey Company"
+        self.assertEqual(public_info.products["candies"][0].name, "Reese's cups")
+        self.assertEqual(public_info.products["candies"][0].brand, "The Hershey Company")
 
-    assert public_info.products["candies"][1].name == "Snickers"
-    assert public_info.products["candies"][1].brand == "Mars, Incorporated"
+        self.assertEqual(public_info.products["candies"][1].name, "Snickers")
+        self.assertEqual(public_info.products["candies"][1].brand, "Mars, Incorporated")
+
+    def test_deepcopy_disabled(self):
+        public_info_deep = mapper.to(ShopPublicInfo).map(self.shop, deepcopy=False)
+        public_info = mapper.to(ShopPublicInfo).map(self.shop)
+
+        self.assertIsNot(public_info.products, self.shop.products)
+        self.assertEqual(public_info.products["magazines"], self.shop.products["magazines"])
+        self.assertNotEqual(public_info.products["magazines"], id(self.shop.products["magazines"]))
+
+        self.assertIs(public_info_deep.products, self.shop.products)
+        self.assertEqual(id(public_info_deep.products["magazines"]), id(self.shop.products["magazines"]))
+
+    def test_deepcopy_disabled_in_add(self):
+        self.mapper.add(Shop, ShopPublicInfo, deepcopy=False)
+        public_info = self.mapper.map(self.shop)
+
+        self.assertIs(public_info.products, self.shop.products)
+
+        # Manually enable deepcopy on .map()
+        public_info = self.mapper.map(self.shop, deepcopy=True)
+        self.assertIsNot(public_info.products, self.shop.products)

--- a/tests/test_automapper_dict_field.py
+++ b/tests/test_automapper_dict_field.py
@@ -37,7 +37,9 @@ class AutomapperTest(TestCase):
         public_info = mapper.to(ShopPublicInfo).map(self.shop)
 
         self.assertEqual(public_info.products["magazines"], self.shop.products["magazines"])
-        self.assertNotEqual(id(public_info.products["magazines"]), id(self.shop.products["magazines"]))
+        self.assertNotEqual(
+            id(public_info.products["magazines"]), id(self.shop.products["magazines"])
+        )
 
         self.assertNotEqual(public_info.products["candies"], self.shop.products["candies"])
         self.assertNotEqual(public_info.products["candies"][0], self.shop.products["candies"][0])
@@ -58,7 +60,9 @@ class AutomapperTest(TestCase):
         self.assertNotEqual(public_info.products["magazines"], id(self.shop.products["magazines"]))
 
         self.assertIs(public_info_deep.products, self.shop.products)
-        self.assertEqual(id(public_info_deep.products["magazines"]), id(self.shop.products["magazines"]))
+        self.assertEqual(
+            id(public_info_deep.products["magazines"]), id(self.shop.products["magazines"])
+        )
 
     def test_deepcopy_disabled_in_add(self):
         self.mapper.add(Shop, ShopPublicInfo, deepcopy=False)

--- a/tests/test_automapper_sample.py
+++ b/tests/test_automapper_sample.py
@@ -20,6 +20,31 @@ class PublicUserInfoDiff:
         self.profession = profession
 
 
+from dataclasses import dataclass
+from automapper import mapper
+
+
+@dataclass
+class Address:
+    street: str
+    number: int
+    zip_code: int
+    city: str
+
+
+class PersonInfo:
+    def __init__(self, name: str, age: int, address: Address):
+        self.name = name
+        self.age = age
+        self.address = address
+
+
+class PublicPersonInfo:
+    def __init__(self, name: str, address: Address):
+        self.name = name
+        self.address = address
+
+
 def test_map__field_with_same_name():
     user_info = UserInfo("John Malkovich", 35, "engineer")
     public_user_info = mapper.to(PublicUserInfo).map(
@@ -79,3 +104,14 @@ def test_map__override_field_value_register():
         assert public_user_info.profession == "engineer"
     finally:
         mapper._mappings.clear()
+
+
+def test_deepcopy():
+    address = Address(street="Main Street", number=1, zip_code=100001, city='Test City')
+    info = PersonInfo('John Doe', age=35, address=address)
+
+    public_info = mapper.to(PublicPersonInfo).map(info)
+    assert address is not public_info.address
+
+    public_info = mapper.to(PublicPersonInfo).map(info, deepcopy=False)
+    assert address is public_info.address

--- a/tests/test_automapper_sample.py
+++ b/tests/test_automapper_sample.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from automapper import mapper
 
 
@@ -18,10 +19,6 @@ class PublicUserInfoDiff:
     def __init__(self, full_name: str, profession: str):
         self.full_name = full_name
         self.profession = profession
-
-
-from dataclasses import dataclass
-from automapper import mapper
 
 
 @dataclass

--- a/tests/test_automapper_sample.py
+++ b/tests/test_automapper_sample.py
@@ -67,9 +67,7 @@ def test_map__field_with_different_name():
 
 def test_map__field_with_different_name_register():
     try:
-        mapper.add(
-            UserInfo, PublicUserInfoDiff, fields_mapping={"full_name": "UserInfo.name"}
-        )
+        mapper.add(UserInfo, PublicUserInfoDiff, fields_mapping={"full_name": "UserInfo.name"})
 
         user_info = UserInfo("John Malkovich", 35, "engineer")
         public_user_info: PublicUserInfoDiff = mapper.map(user_info)
@@ -107,8 +105,8 @@ def test_map__override_field_value_register():
 
 
 def test_deepcopy():
-    address = Address(street="Main Street", number=1, zip_code=100001, city='Test City')
-    info = PersonInfo('John Doe', age=35, address=address)
+    address = Address(street="Main Street", number=1, zip_code=100001, city="Test City")
+    info = PersonInfo("John Doe", age=35, address=address)
 
     public_info = mapper.to(PublicPersonInfo).map(info)
     assert address is not public_info.address

--- a/tests/test_for_complex_obj.py
+++ b/tests/test_for_complex_obj.py
@@ -20,9 +20,7 @@ class ChildClass(ParentClass):
 
     @classmethod
     def fields(cls) -> Iterable[str]:
-        return (
-            field for field in cls.__init__.__annotations__.keys() if field != "return"
-        )
+        return (field for field in cls.__init__.__annotations__.keys() if field != "return")
 
 
 class AnotherClass:
@@ -73,9 +71,7 @@ class MappingComplexObjTest(TestCase):
         self.mapper = create_mapper()
 
     def test_map__complext_obj(self):
-        complex_obj = ComplexClass(
-            obj=ChildClass(15, "nested_obj_msg", True), text="obj_msg"
-        )
+        complex_obj = ComplexClass(obj=ChildClass(15, "nested_obj_msg", True), text="obj_msg")
         self.mapper.add(ChildClass, AnotherClass)
         self.mapper.add(ComplexClass, AnotherComplexClass)
 

--- a/tests/test_for_sqlalchemy_extention.py
+++ b/tests/test_for_sqlalchemy_extention.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import declarative_base
 Base = declarative_base()
 
 
-class UserInfo(Base):
+class UserInfo(Base):  # type: ignore[misc,valid-type]
     __tablename__ = "users"
     id = Column(Integer, primary_key=True)
     full_name = Column(String)
@@ -24,7 +24,7 @@ class UserInfo(Base):
         )
 
 
-class PublicUserInfo(Base):
+class PublicUserInfo(Base):  # type: ignore[misc,valid-type]
     __tablename__ = "public_users"
     id = Column(Integer, primary_key=True)
     public_name = Column(String)


### PR DESCRIPTION
Very minor flaw I encountered during testing: As `target_cls` is typically a type. It would print `<class 'type'>` which is not very informative.