### PR TITLE
Fix mapping of string enum types

### DIFF
--- a/automapper/mapper.py
+++ b/automapper/mapper.py
@@ -1,5 +1,6 @@
 import inspect
 from copy import deepcopy
+from enum import Enum
 from typing import (
     Any,
     Callable,
@@ -49,6 +50,11 @@ def _object_contains(obj: Any, field_name: str) -> bool:
 def _is_primitive(obj: Any) -> bool:
     """Check if object type is primitive"""
     return type(obj) in __PRIMITIVE_TYPES
+
+
+def _is_enum(obj: Any) -> bool:
+    """Check if object type is enum"""
+    return issubclass(type(obj), Enum)
 
 
 def _try_get_field_value(
@@ -267,7 +273,7 @@ class Mapper:
         self, obj: S, _visited_stack: Set[int], skip_none_values: bool = False
     ) -> Any:
         """Maps subobjects recursively"""
-        if _is_primitive(obj):
+        if _is_primitive(obj) or _is_enum(obj):
             return obj
 
         obj_id = id(obj)

--- a/tests/test_automapper_enum.py
+++ b/tests/test_automapper_enum.py
@@ -1,0 +1,49 @@
+from enum import Enum
+from typing import Tuple
+
+from automapper import mapper
+
+
+class StringEnum(str, Enum):
+    Value1 = "value1"
+    Value2 = "value2"
+    Value3 = "value3"
+
+
+class IntEnum(int, Enum):
+    Value1 = 1
+    Value2 = 2
+    Value3 = 3
+
+
+class TupleEnum(Tuple[str, str], Enum):
+    Value1 = ("value", "1")
+    Value2 = ("value", "2")
+    Value3 = ("value", "3")
+
+
+class SourceClass:
+    def __init__(
+        self, string_value: StringEnum, int_value: IntEnum, tuple_value: TupleEnum
+    ) -> None:
+        self.string_value = string_value
+        self.int_value = int_value
+        self.tuple_value = tuple_value
+
+
+class TargetClass:
+    def __init__(
+        self, string_value: StringEnum, int_value: IntEnum, tuple_value: TupleEnum
+    ) -> None:
+        self.string_value = string_value
+        self.int_value = int_value
+        self.tuple_value = tuple_value
+
+
+def test_map__enum():
+    src = SourceClass(StringEnum.Value1, IntEnum.Value2, TupleEnum.Value3)
+    dst = mapper.to(TargetClass).map(src)
+
+    assert dst.string_value == StringEnum.Value1
+    assert dst.int_value == IntEnum.Value2
+    assert dst.tuple_value == TupleEnum.Value3


### PR DESCRIPTION
I noticed that mapping of string enums currently doesn't work as the mapper handles such values as an iterable and returns a list of the individual characters of the enum value. I added a simple fix to handle enum values the same as primitive values.