### PR TITLE
fix: Pydantic v2 warning on deprecated `__fields__` BaseModel property access

### DIFF
--- a/automapper/extensions/pydantic.py
+++ b/automapper/extensions/pydantic.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 
 def spec_function(target_cls: Type[BaseModel]) -> Iterable[str]:
-    return (field_name for field_name in getattr(target_cls, "__fields__"))
+    return (field_name for field_name in target_cls.model_fields)
 
 
 def extend(mapper: Mapper) -> None:


### PR DESCRIPTION
See in [pydantic](https://github.com/pydantic/pydantic/blob/32f405bcf6171602ffe754f1fca1681c5ddee96e/pydantic/_internal/_model_construction.py#L350)